### PR TITLE
fix: set base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { resolve } from 'path';
 export default defineConfig(async () => {
   const { default: cssInjectedByJsPlugin } = await import('vite-plugin-css-injected-by-js');
   return {
+    base: '/synt/',
     root: 'src',
     publicDir: '../public',
     build: {
@@ -17,6 +18,7 @@ export default defineConfig(async () => {
           entryFileNames: '[name].js',
         },
       },
+      chunkSizeWarningLimit: 1000,
     },
     plugins: [
       cssInjectedByJsPlugin(),


### PR DESCRIPTION
## Problem

When deployed to GitHub Pages at `https://pitpit.github.io/synt/`, the built `index.html` referenced assets with an absolute path `/synt.js`, causing a 404:

```
GET https://pitpit.github.io/synt.js net::ERR_ABORTED 404 (Not Found)
```

## Fix

Set `base: '/synt/'` in `vite.config.ts` so Vite generates asset paths prefixed with `/synt/`, resolving correctly to `https://pitpit.github.io/synt/synt.js`.